### PR TITLE
Preserve order of extra section, only merge patches

### DIFF
--- a/src/Composer/ComposerPatchesConfigurationUpdater.php
+++ b/src/Composer/ComposerPatchesConfigurationUpdater.php
@@ -40,11 +40,12 @@ final readonly class ComposerPatchesConfigurationUpdater
     {
         $composerJson = FileSystem::loadFileToJson($composerJsonFilePath);
 
-        // merge "extra" section - deep merge is needed, so original patches are included
+        // merge "extra.patches" section - deep merge is needed, so original patches are included
         if (isset($composerJson['extra'])) {
-            $composerJson['extra'] = $this->parametersMerger->merge($composerJson['extra'], [
-                'patches' => $composerExtraPatches,
-            ]);
+            $composerJson['extra']['patches'] = $this->parametersMerger->merge(
+                $composerJson['extra']['patches'] ?? [],
+                $composerExtraPatches
+            );
 
             return $composerJson;
         }

--- a/tests/Composer/ComposerPatchesConfigurationUpdater/ComposerPatchesConfigurationUpdaterTest.php
+++ b/tests/Composer/ComposerPatchesConfigurationUpdater/ComposerPatchesConfigurationUpdaterTest.php
@@ -47,6 +47,29 @@ final class ComposerPatchesConfigurationUpdaterTest extends AbstractTestCase
         ], $patchesFileJson);
     }
 
+    public function testComposerJsonPreservesExtraKeyOrder(): void
+    {
+        $composerPatchesConfigurationUpdater = $this->make(ComposerPatchesConfigurationUpdater::class);
+
+        $composerJson = $composerPatchesConfigurationUpdater->updateComposerJson(
+            __DIR__ . '/Fixture/composer.extra_with_sibling_keys.json',
+            [
+                'nette/di' => ['nette-di.patch'],
+            ]
+        );
+
+        $this->assertSame([
+            'branch-alias' => [
+                'dev-main' => '1.0-dev',
+            ],
+            'patches' => [
+                'nette/di' => ['nette-di.patch'],
+                'symfony/console' => ['patches/symfony-console-style-symfonystyle-php.patch'],
+            ],
+        ], $composerJson['extra']);
+        $this->assertSame(['branch-alias', 'patches'], array_keys($composerJson['extra']));
+    }
+
     public function testComposerJsonAndPrint(): void
     {
         $composerPatchesConfigurationUpdater = $this->make(ComposerPatchesConfigurationUpdater::class);

--- a/tests/Composer/ComposerPatchesConfigurationUpdater/Fixture/composer.extra_with_sibling_keys.json
+++ b/tests/Composer/ComposerPatchesConfigurationUpdater/Fixture/composer.extra_with_sibling_keys.json
@@ -1,0 +1,12 @@
+{
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.0-dev"
+        },
+        "patches": {
+            "symfony/console": [
+                "patches/symfony-console-style-symfonystyle-php.patch"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This pull request updates how the `extra.patches` section is merged in the Composer JSON configuration to ensure only the `patches` key is deep-merged, preserving the order and content of sibling keys in the `extra` section. It also adds a test to verify this behavior.
