### PR TITLE
Add alternative package name resolving option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,16 +143,26 @@ composer install
 
 ## Patches File and Patches Folder Options
 
-Optionally, if you use a [patches file](https://docs.cweagans.net/composer-patches/usage/defining-patches/#patches-file) you can specify its path using the `--patches-file` option:
+Optionally, if you use a [patches file](https://docs.cweagans.net/composer-patches/usage/defining-patches/#patches-file) you can specify its path as the first argument:
 
 ```bash
-vendor/bin/vendor-patches generate --patches-file=patches.json
+vendor/bin/vendor-patches generate patches.json
 ```
 
-You can choose to write the patches to a different folder than the default 'patches' folder by specifying the folder name using the `--patches-folder` option:
+You can choose to write the patches to a different folder than the default 'patches' folder by specifying the folder name using the `--patches-output` option:
 
 ```bash
-vendor/bin/vendor-patches generate --patches-folder=patches-composer
+vendor/bin/vendor-patches generate --patches-output=patches-composer
+```
+
+<br>
+
+## Resolve From Directory Option
+
+By default, the package name is read from each package's `composer.json` `name` field. Use `--resolve-from-directory` to derive the package name from its `vendor/<vendor>/<package>` directory instead. Useful for private repositories where the installed directory name differs from the `name` in `composer.json`.
+
+```bash
+vendor/bin/vendor-patches generate --resolve-from-directory
 ```
 
 <br>

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ composer install
 
 ## Patches File and Patches Folder Options
 
-Optionally, if you use a [patches file](https://docs.cweagans.net/composer-patches/usage/defining-patches/#patches-file) you can specify its path as the first argument:
+Optionally, if you use a [patches file](https://docs.cweagans.net/composer-patches/usage/defining-patches/#patches-file) you can specify its path using the `--patches-file` option:
 
 ```bash
-vendor/bin/vendor-patches generate patches.json
+vendor/bin/vendor-patches generate --patches-file=patches.json
 ```
 
 You can choose to write the patches to a different folder than the default 'patches' folder by specifying the folder name using the `--patches-output` option:

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -30,14 +30,18 @@ final readonly class GenerateCommand implements CommandInterface
     /**
      * @param string|null $patchesFile Path to the patches file, relative to project root
      * @param string|null $patchesOutput Folder to output the patches to.
+     * @param bool|null $resolveFromDirectory Resolve package name from path in vendor/ instead of the package's composer.json. This is useful for private repositories where the name in the repository differs from the name in composer.json.
      *
      * @return \Entropy\Console\Enum\ExitCode::*
      */
-    public function run(?string $patchesFile = null, ?string $patchesOutput = null): int
-    {
+    public function run(
+        ?string $patchesFile = null,
+        ?string $patchesOutput = null,
+        ?bool $resolveFromDirectory = false
+    ): int {
         $projectVendorDirectory = $this->resolveProjectVendorDirectory();
 
-        $oldAndNewFiles = $this->oldToNewFilesFinder->find($projectVendorDirectory);
+        $oldAndNewFiles = $this->oldToNewFilesFinder->find($projectVendorDirectory, (bool) $resolveFromDirectory);
 
         $composerExtraPatches = [];
         $addedPatchFilesByPackageName = [];

--- a/src/Composer/PackageNameResolver.php
+++ b/src/Composer/PackageNameResolver.php
@@ -14,7 +14,7 @@ use Webmozart\Assert\Assert;
  */
 final class PackageNameResolver
 {
-    public function resolveFromFilePath(string $vendorFile): string
+    public function resolveFromPackageComposerJson(string $vendorFile): string
     {
         $packageComposerJsonFilePath = $this->getPackageComposerJsonFilePath($vendorFile);
 
@@ -24,6 +24,13 @@ final class PackageNameResolver
         }
 
         return $composerJson['name'];
+    }
+
+    public function resolveFromVendorDirectory(string $vendorFile): string
+    {
+        $vendorPackageDirectory = PathResolver::resolveVendorDirectory($vendorFile);
+
+        return basename(dirname($vendorPackageDirectory)) . '/' . basename($vendorPackageDirectory);
     }
 
     private function getPackageComposerJsonFilePath(string $vendorFilePath): string

--- a/src/Finder/OldToNewFilesFinder.php
+++ b/src/Finder/OldToNewFilesFinder.php
@@ -21,7 +21,7 @@ final readonly class OldToNewFilesFinder
     /**
      * @return OldAndNewFile[]
      */
-    public function find(string $directory): array
+    public function find(string $directory, bool $resolveFromDirectory = false): array
     {
         $oldAndNewFiles = [];
 
@@ -38,7 +38,12 @@ final readonly class OldToNewFilesFinder
                 continue;
             }
 
-            $packageName = $this->packageNameResolver->resolveFromFilePath($newFilePath);
+            if ($resolveFromDirectory) {
+                $packageName = $this->packageNameResolver->resolveFromVendorDirectory($newFilePath);
+            } else {
+                $packageName = $this->packageNameResolver->resolveFromPackageComposerJson($newFilePath);
+            }
+
             $oldAndNewFiles[] = new OldAndNewFile($oldFilePath, $newFilePath, $packageName);
         }
 

--- a/tests/Composer/PackageNameResolverTest.php
+++ b/tests/Composer/PackageNameResolverTest.php
@@ -9,14 +9,25 @@ use Symplify\VendorPatches\Tests\AbstractTestCase;
 
 final class PackageNameResolverTest extends AbstractTestCase
 {
-    public function test(): void
+    public function testResolveFromPackageComposerJson(): void
     {
         $packageNameResolver = $this->make(PackageNameResolver::class);
 
-        $packageName = $packageNameResolver->resolveFromFilePath(
+        $packageName = $packageNameResolver->resolveFromPackageComposerJson(
             __DIR__ . '/PackageNameResolverSource/vendor/some/pac.kage/composer.json'
         );
 
         $this->assertSame('some/name', $packageName);
+    }
+
+    public function testResolveFromVendorDirectory(): void
+    {
+        $packageNameResolver = $this->make(PackageNameResolver::class);
+
+        $packageName = $packageNameResolver->resolveFromVendorDirectory(
+            __DIR__ . '/PackageNameResolverSource/vendor/some/pac.kage/src/SomeFile.php'
+        );
+
+        $this->assertSame('some/pac.kage', $packageName);
     }
 }


### PR DESCRIPTION
This pull request introduces a new option to resolve package names from the vendor directory instead of the `composer.json` file, which is useful for private repositories where the installed directory name may differ from the package name in `composer.json`. 

Added a `--resolve-from-directory` option to the CLI and updated the documentation in `README.md` to explain its usage and when it's helpful