### PR TITLE
fix: feat: Add commands do copy/backup vendor files and cleanup (fixes symplify/vendor-patches#56)

### DIFF
--- a/src/Command/BackupCommand.php
+++ b/src/Command/BackupCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\VendorPatches\Command;
+
+use Entropy\Console\Contract\CommandInterface;
+use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
+
+final readonly class BackupCommand implements CommandInterface
+{
+    public function __construct(
+        private OutputPrinter $outputPrinter,
+    ) {
+    }
+
+    /**
+     * @param string ...$files Vendor files to back up by copying them to "<path>.old"
+     *
+     * @return \Entropy\Console\Enum\ExitCode::*
+     */
+    public function run(string ...$files): int
+    {
+        if ($files === []) {
+            $this->outputPrinter->redBackground('No files provided. Pass one or more vendor file paths to back up.');
+            return ExitCode::ERROR;
+        }
+
+        $backupCount = 0;
+
+        foreach ($files as $file) {
+            if (! is_file($file)) {
+                $this->outputPrinter->redBackground(sprintf('File "%s" was not found', $file));
+                return ExitCode::ERROR;
+            }
+
+            $backupFile = $file . '.old';
+
+            if (is_file($backupFile)) {
+                $this->outputPrinter->orangeBackground(
+                    sprintf('Backup "%s" already exists, skipping', $backupFile)
+                );
+                continue;
+            }
+
+            if (! copy($file, $backupFile)) {
+                $this->outputPrinter->redBackground(sprintf('Failed to create backup "%s"', $backupFile));
+                return ExitCode::ERROR;
+            }
+
+            $this->outputPrinter->yellow(sprintf('File "%s" was backed up', $backupFile));
+            ++$backupCount;
+        }
+
+        if ($backupCount > 0) {
+            $this->outputPrinter->greenBackground(sprintf('%d backup file(s) created', $backupCount));
+        } else {
+            $this->outputPrinter->greenBackground('No new backup files were created');
+        }
+
+        return ExitCode::SUCCESS;
+    }
+
+    public function getName(): string
+    {
+        return 'backup';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Create *.old backup copies of given /vendor files';
+    }
+}

--- a/src/Command/CleanupCommand.php
+++ b/src/Command/CleanupCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\VendorPatches\Command;
+
+use Entropy\Console\Contract\CommandInterface;
+use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
+use Symfony\Component\Finder\Finder;
+use Symplify\VendorPatches\VendorDirProvider;
+
+final readonly class CleanupCommand implements CommandInterface
+{
+    public function __construct(
+        private OutputPrinter $outputPrinter,
+    ) {
+    }
+
+    /**
+     * @return \Entropy\Console\Enum\ExitCode::*
+     */
+    public function run(): int
+    {
+        $projectVendorDirectory = $this->resolveProjectVendorDirectory();
+
+        $finder = Finder::create()
+            ->in($projectVendorDirectory)
+            ->files()
+            ->exclude('composer/')
+            ->exclude('ocramius/')
+            ->name('*.old');
+
+        $deletedCount = 0;
+
+        foreach ($finder as $fileInfo) {
+            $filePath = $fileInfo->getPathname();
+
+            if (! unlink($filePath)) {
+                $this->outputPrinter->redBackground(sprintf('Failed to remove "%s"', $filePath));
+                return ExitCode::ERROR;
+            }
+
+            $this->outputPrinter->yellow(sprintf('File "%s" was removed', $filePath));
+            ++$deletedCount;
+        }
+
+        if ($deletedCount > 0) {
+            $this->outputPrinter->greenBackground(sprintf('%d *.old file(s) removed', $deletedCount));
+        } else {
+            $this->outputPrinter->greenBackground('No *.old files were found');
+        }
+
+        return ExitCode::SUCCESS;
+    }
+
+    public function getName(): string
+    {
+        return 'cleanup';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Remove all *.old backup files from /vendor directory';
+    }
+
+    private function resolveProjectVendorDirectory(): string
+    {
+        $projectVendorDirectory = getcwd() . '/vendor';
+        if (file_exists($projectVendorDirectory)) {
+            return $projectVendorDirectory;
+        }
+
+        return VendorDirProvider::provide();
+    }
+}

--- a/tests/Command/BackupCommandTest.php
+++ b/tests/Command/BackupCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\VendorPatches\Tests\Command;
+
+use Entropy\Console\Enum\ExitCode;
+use Symplify\VendorPatches\Command\BackupCommand;
+use Symplify\VendorPatches\Tests\AbstractTestCase;
+
+final class BackupCommandTest extends AbstractTestCase
+{
+    private string $workDirectory;
+
+    protected function setUp(): void
+    {
+        $this->workDirectory = sys_get_temp_dir() . '/vendor-patches-backup-' . uniqid();
+        mkdir($this->workDirectory, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDirectory . '/*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->workDirectory);
+    }
+
+    public function testCreatesOldBackupFile(): void
+    {
+        $sourceFile = $this->workDirectory . '/Sample.php';
+        file_put_contents($sourceFile, "<?php\n// sample\n");
+
+        $backupCommand = $this->make(BackupCommand::class);
+        $exitCode = $backupCommand->run($sourceFile);
+
+        $this->assertSame(ExitCode::SUCCESS, $exitCode);
+        $this->assertFileExists($sourceFile . '.old');
+        $this->assertSame(file_get_contents($sourceFile), file_get_contents($sourceFile . '.old'));
+    }
+
+    public function testBacksUpMultipleFiles(): void
+    {
+        $first = $this->workDirectory . '/First.php';
+        $second = $this->workDirectory . '/Second.php';
+        file_put_contents($first, '<?php // first');
+        file_put_contents($second, '<?php // second');
+
+        $backupCommand = $this->make(BackupCommand::class);
+        $exitCode = $backupCommand->run($first, $second);
+
+        $this->assertSame(ExitCode::SUCCESS, $exitCode);
+        $this->assertFileExists($first . '.old');
+        $this->assertFileExists($second . '.old');
+    }
+
+    public function testReturnsErrorWhenNoFilesProvided(): void
+    {
+        $backupCommand = $this->make(BackupCommand::class);
+        $exitCode = $backupCommand->run();
+
+        $this->assertSame(ExitCode::ERROR, $exitCode);
+    }
+
+    public function testReturnsErrorWhenFileMissing(): void
+    {
+        $backupCommand = $this->make(BackupCommand::class);
+        $exitCode = $backupCommand->run($this->workDirectory . '/does-not-exist.php');
+
+        $this->assertSame(ExitCode::ERROR, $exitCode);
+    }
+
+    public function testDoesNotOverwriteExistingBackup(): void
+    {
+        $sourceFile = $this->workDirectory . '/Sample.php';
+        file_put_contents($sourceFile, '<?php // new content');
+        file_put_contents($sourceFile . '.old', '<?php // original');
+
+        $backupCommand = $this->make(BackupCommand::class);
+        $exitCode = $backupCommand->run($sourceFile);
+
+        $this->assertSame(ExitCode::SUCCESS, $exitCode);
+        $this->assertSame('<?php // original', file_get_contents($sourceFile . '.old'));
+    }
+}

--- a/tests/Command/BackupCommandTest.php
+++ b/tests/Command/BackupCommandTest.php
@@ -23,6 +23,7 @@ final class BackupCommandTest extends AbstractTestCase
         foreach (glob($this->workDirectory . '/*') ?: [] as $file) {
             unlink($file);
         }
+
         rmdir($this->workDirectory);
     }
 

--- a/tests/Command/CleanupCommandTest.php
+++ b/tests/Command/CleanupCommandTest.php
@@ -69,9 +69,13 @@ final class CleanupCommandTest extends AbstractTestCase
         }
 
         foreach (scandir($path) ?: [] as $entry) {
-            if ($entry === '.' || $entry === '..') {
+            if ($entry === '.') {
                 continue;
             }
+            if ($entry === '..') {
+                continue;
+            }
+
             $this->removeRecursive($path . '/' . $entry);
         }
 

--- a/tests/Command/CleanupCommandTest.php
+++ b/tests/Command/CleanupCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\VendorPatches\Tests\Command;
+
+use Entropy\Console\Enum\ExitCode;
+use Symplify\VendorPatches\Command\CleanupCommand;
+use Symplify\VendorPatches\Tests\AbstractTestCase;
+
+final class CleanupCommandTest extends AbstractTestCase
+{
+    private string $workDirectory;
+
+    private string $originalCwd;
+
+    protected function setUp(): void
+    {
+        $this->workDirectory = sys_get_temp_dir() . '/vendor-patches-cleanup-' . uniqid();
+        mkdir($this->workDirectory . '/vendor/some/package/src', 0777, true);
+
+        $this->originalCwd = (string) getcwd();
+        chdir($this->workDirectory);
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->originalCwd);
+        $this->removeRecursive($this->workDirectory);
+    }
+
+    public function testRemovesOldFiles(): void
+    {
+        $vendorDir = $this->workDirectory . '/vendor';
+        $oldFileA = $vendorDir . '/some/package/src/A.php.old';
+        $oldFileB = $vendorDir . '/some/package/src/B.php.old';
+        $kept = $vendorDir . '/some/package/src/A.php';
+
+        file_put_contents($oldFileA, '<?php // old A');
+        file_put_contents($oldFileB, '<?php // old B');
+        file_put_contents($kept, '<?php // current');
+
+        $cleanupCommand = $this->make(CleanupCommand::class);
+        $exitCode = $cleanupCommand->run();
+
+        $this->assertSame(ExitCode::SUCCESS, $exitCode);
+        $this->assertFileDoesNotExist($oldFileA);
+        $this->assertFileDoesNotExist($oldFileB);
+        $this->assertFileExists($kept);
+    }
+
+    public function testReturnsSuccessWhenNothingToRemove(): void
+    {
+        $cleanupCommand = $this->make(CleanupCommand::class);
+        $exitCode = $cleanupCommand->run();
+
+        $this->assertSame(ExitCode::SUCCESS, $exitCode);
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (! file_exists($path)) {
+            return;
+        }
+
+        if (is_file($path) || is_link($path)) {
+            unlink($path);
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $this->removeRecursive($path . '/' . $entry);
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes symplify/vendor-patches#56 — feat: Add commands do copy/backup vendor files and cleanup

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/handyman.php. Please review carefully before merging.